### PR TITLE
DPI-3377: fix error when building package on newer versions of R

### DIFF
--- a/data-raw/country.codes.R
+++ b/data-raw/country.codes.R
@@ -28,7 +28,7 @@ loadPkgData <- function(fname)
              " to create this data set.")
 
     }
-    readRDS(data.file, .GlobalEnv)
+    readRDS(data.file)
     return(invisible())
 }
 

--- a/data-raw/country.codes.R
+++ b/data-raw/country.codes.R
@@ -28,7 +28,7 @@ loadPkgData <- function(fname)
              " to create this data set.")
 
     }
-    load(data.file, .GlobalEnv)
+    readRDS(data.file, .GlobalEnv)
     return(invisible())
 }
 


### PR DESCRIPTION
When building `flipGeoData` in Nix I encountered the below error.

[Build output:](https://github.com/Displayr/NixR/actions/runs/15969081535/job/45035969138#step:5:56)
```
> Warning: file 'australia.post.codes.rda' has magic number 'versi'
>   Use of save versions prior to 2 is deprecated
> Error in load(p, envir = env) :
>   bad restore file magic number (file may be corrupted) -- no data loaded
> Execution halted
```

This change fixes the error, and all of the tests (when run by Nix) pass. 
That said, I pulled this off of [SO](https://stackoverflow.com/a/21505731), and don't have a meaningful understanding of what this change does or why it seemingly fixes the error.

I'm not sure why the Nix CI is showing the same error as if this fix isn't applied - building locally it compiles without error. I suspect it is because the change I've made works with R 4.5.0 but doesn't with 4.4.2, which is what `NixR` has on its default branch, as the 4.5.0 branch isn't merged yet. I'm building against the default branch locally to confirm if this is accurate.

There are warnings, but I found the last CircleCI build log and the warnings are present there also.

This is the build log I get locally:
```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/fsi2rshwlw2wxnyyik7365w8af3lmv6r-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
* checking for file './DESCRIPTION' ... OK
* preparing 'flipGeoData':
* checking DESCRIPTION meta-information ... OK
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
Removed empty directory 'flipGeoData/.circleci'
* looking to see if a 'data/datalist' file should be added
* re-saving image files
Warning in load(p, envir = env) :
  strings not representable in native encoding will be translated to UTF-8
Warning in load(p, envir = env) :
  input string 'Te Taihau <c4><81> uru|WC|NZ-WTC|WTC|West Coast Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string '<c5><8c> T<c4><81>kou|OT|NZ-OTA|OTA|Otago Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'T<c4><81>maki-makau-rau|AU|NZ-AUK|AUK|Auckland Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Te Matau a M<c4><81>ui|Hawkes Bay|HB|NZ-HKB|HKB|Hawke's Bay Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string '<d0><91><d1><80><d0><b5><d1><81><d1><82>|Brestskaya Voblasts'|Br<c3><a8>st|Brest|BY-BR|BY.BR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string '<d0><92><d0><b8><d1><82><d0><b5><d0><b1><d1><81><d0><ba>|Vicebsk|Vitebsk|Vitsyebskaya Voblasts'|Witebsk|Vitsyebsk|BY-VI|BY.VI' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Rundales|Rund<c4><81>le|Jekabpils|Rundales Novads|LV-083|LV.RD' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Vev<c4><8d>ani|Vevcani|Opstina Vevcani|Vevcani, Opstina|MK-12|MK.VV' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Kanal|Kanal ob So<c4><8d>i|Obcina Kanal|Kanal, Obcina|SI-044|SI.SP.KA' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Delcevo|Del<c4><8d>evo|Opstina Delcevo|Delcevo, Opstina|MK-23|MK.DL' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Apace|Apa<c4><8d>e|Gornja Radgona|Obcina Apace|Apace, Obcina|SI-195|SI.PM.GR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Liep<c4><81>ja|Liepaja|LV-LPX|LV.LJ' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Marupes|M<c4><81>rupe|Riga|Marupes Novads|LV-062|LV.MR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Malpils|M<c4><81>lpils|Riga|Malpils Novads|LV-061|LV.ML' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Lielvardes|Lielv<c4><81>rde|Riga|Lielvardes Novads|LV-053|LV.LL' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Tiobraid <c3><81>rann|North Tipperary|Tipperary|Tipperary North Riding|North Tipperary, County|IE-TA|IE.TY' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Tiobraid <c3><81>rann|South Tipperary|Tipperary|Tipperary South Riding|South Tipperary, County|IE-TA|IE.TY' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string '<d0><9c><d0><b8><d0><bd><d1><81><d0><ba>|<d0><9c><d0><b8><d0><bd><d1><81><d0><ba><d0><b0><d1><8f> <d0><9e><d0><b1><d0><bb><d0><b0><d1><81><d1><82><d1><8c>|Minsk Oblast|Minskaya Voblasts'|Minsk|BY-MI|BY.MI' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Aracinovo|Ara<c4><8d>inovo|Aracinovo Municipality|Opstina Aracinovo|Aracinovo, Opstina|MK-02|MK.AR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Kicevo|Ki<c4><8d>evo|Opstina Kicevo|Kicevo, Opstina|MK-40|MK.KH' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Kocani|Ko<c4><8d>ani|Opstina Kocani|Kocani, Opstina|MK-42|MK.OC' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Konce|Kon<c4><8d>e|Konce Municipality|Opstina Konce|Konce, Opstina|MK-41|MK.KN' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string '<d0><9c><d0><b8><d0><bd><d1><81><d0><ba>|<d0><9c><d0><b8><d0><bd><d1><81><d0><ba><d0><b0><d1><8f> <d0><9e><d0><b1><d0><bb><d0><b0><d1><81><d1><82><d1><8c>|Minsk Oblast|Minskaya Voblasts'|City of Minsk|Minsk|Horad Minsk|Minsk, Horad|BY-HM|BY.HM' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(p, envir = env) :
  input string 'Incukalna|In<c4><8d>ukalns|Riga|Incukalna Novads|LV-037|LV.IN' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
* building 'flipGeoData_0.6.5.tar.gz'

Built compiled package at: /build/source/flipGeoData_0.6.5.tar.gz
buildPhase completed in 1 minutes 6 seconds
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Warning: invalid package 'pkgconfigdir=/nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5/lib/pkgconfig'
Warning: invalid package 'm4datadir=/nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5/share/aclocal'
Warning: invalid package 'aclocaldir=/nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5/share/aclocal'
* installing *source* package 'flipGeoData' ...
** this is package 'flipGeoData' version '0.6.5'
** using staged installation
** R
Warning in load(srcFile, e) :
  strings not representable in native encoding will be translated to UTF-8
Warning in load(srcFile, e) :
  input string 'Te Taihau <c4><81> uru|WC|NZ-WTC|WTC|West Coast Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string '<c5><8c> T<c4><81>kou|OT|NZ-OTA|OTA|Otago Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'T<c4><81>maki-makau-rau|AU|NZ-AUK|AUK|Auckland Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Te Matau a M<c4><81>ui|Hawkes Bay|HB|NZ-HKB|HKB|Hawke's Bay Region' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string '<d0><91><d1><80><d0><b5><d1><81><d1><82>|Brestskaya Voblasts'|Br<c3><a8>st|Brest|BY-BR|BY.BR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string '<d0><92><d0><b8><d1><82><d0><b5><d0><b1><d1><81><d0><ba>|Vicebsk|Vitebsk|Vitsyebskaya Voblasts'|Witebsk|Vitsyebsk|BY-VI|BY.VI' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Rundales|Rund<c4><81>le|Jekabpils|Rundales Novads|LV-083|LV.RD' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Vev<c4><8d>ani|Vevcani|Opstina Vevcani|Vevcani, Opstina|MK-12|MK.VV' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Kanal|Kanal ob So<c4><8d>i|Obcina Kanal|Kanal, Obcina|SI-044|SI.SP.KA' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Delcevo|Del<c4><8d>evo|Opstina Delcevo|Delcevo, Opstina|MK-23|MK.DL' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Apace|Apa<c4><8d>e|Gornja Radgona|Obcina Apace|Apace, Obcina|SI-195|SI.PM.GR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Liep<c4><81>ja|Liepaja|LV-LPX|LV.LJ' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Marupes|M<c4><81>rupe|Riga|Marupes Novads|LV-062|LV.MR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Malpils|M<c4><81>lpils|Riga|Malpils Novads|LV-061|LV.ML' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Lielvardes|Lielv<c4><81>rde|Riga|Lielvardes Novads|LV-053|LV.LL' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Tiobraid <c3><81>rann|North Tipperary|Tipperary|Tipperary North Riding|North Tipperary, County|IE-TA|IE.TY' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Tiobraid <c3><81>rann|South Tipperary|Tipperary|Tipperary South Riding|South Tipperary, County|IE-TA|IE.TY' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string '<d0><9c><d0><b8><d0><bd><d1><81><d0><ba>|<d0><9c><d0><b8><d0><bd><d1><81><d0><ba><d0><b0><d1><8f> <d0><9e><d0><b1><d0><bb><d0><b0><d1><81><d1><82><d1><8c>|Minsk Oblast|Minskaya Voblasts'|Minsk|BY-MI|BY.MI' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Aracinovo|Ara<c4><8d>inovo|Aracinovo Municipality|Opstina Aracinovo|Aracinovo, Opstina|MK-02|MK.AR' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Kicevo|Ki<c4><8d>evo|Opstina Kicevo|Kicevo, Opstina|MK-40|MK.KH' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Kocani|Ko<c4><8d>ani|Opstina Kocani|Kocani, Opstina|MK-42|MK.OC' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Konce|Kon<c4><8d>e|Konce Municipality|Opstina Konce|Konce, Opstina|MK-41|MK.KN' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string '<d0><9c><d0><b8><d0><bd><d1><81><d0><ba>|<d0><9c><d0><b8><d0><bd><d1><81><d0><ba><d0><b0><d1><8f> <d0><9e><d0><b1><d0><bb><d0><b0><d1><81><d1><82><d1><8c>|Minsk Oblast|Minskaya Voblasts'|City of Minsk|Minsk|Horad Minsk|Minsk, Horad|BY-HM|BY.HM' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
Warning in load(srcFile, e) :
  input string 'Incukalna|In<c4><8d>ukalns|Riga|Incukalna Novads|LV-037|LV.IN' cannot be translated from 'CP1252' to UTF-8, but is valid UTF-8
** data
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
* DONE (flipGeoData)
> source('/nix/store/4gfvh974j6s1b30lnkcxkar28lqdfhwv-generate_static_html_help.R'); static_help('flipGeoData')
* Making static html help pages for flipGeoData in /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5/library/flipGeoData/html
* Generating RecodeGeography.html
* Generating ReverseGeocode.html
* Generating australia.post.codes.html
* Generating canada.postal.codes.html
* Generating country.codes.html
* Generating euro.post.codes.html
* Generating new.zealand.post.codes.html
* Generating uk.post.codes.html
* Generating us.zip.codes.html
> 
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5
checking for references to /build/ in /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5...
patching script interpreter paths in /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5
shrinking RPATHs of ELF executables and libraries in /nix/store/6xy4r7siksf5hakfnlh034i7r4b96mv7-r-flipGeoData-0.6.5-outarchive
checking for references to /build/ in /nix/store/6xy4r7siksf5hakfnlh034i7r4b96mv7-r-flipGeoData-0.6.5-outarchive...
patching script interpreter paths in /nix/store/6xy4r7siksf5hakfnlh034i7r4b96mv7-r-flipGeoData-0.6.5-outarchive
rewriting symlink /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5/nix-support/propagated-user-env-packages to be relative to /nix/store/h263dwrl386cfimcsdcxpcfy8nvjys6z-r-flipGeoData-0.6.5

```
